### PR TITLE
Renderable::render_next now has mutable &mut self parameter.

### DIFF
--- a/examples/test_synth.rs
+++ b/examples/test_synth.rs
@@ -54,9 +54,12 @@ impl Plugin for RSynthExample {
             position: Cell::new(0usize),
         };
 
-        let voice = VoiceBuilder::new_with_sound(sound)
-            .sample_rate(DEFAULT_SAMPLE_RATE)
-            .finalize();
+        let voice = Voice::new(
+            VoiceDataBuilder::default()
+                .sample_rate(DEFAULT_SAMPLE_RATE)
+                .finalize(),
+            sound
+        );
 
         self.synth = Synth::new()
 						.voices(vec![voice; 6])
@@ -86,13 +89,12 @@ pub struct Sound {
 /// The DSP stuff goes here
 impl Renderable for Sound {
     #[allow(unused_variables)]
-    fn render_next<F: Float + AsPrim, T>(
-        &self,
+    fn render_next<F: Float + AsPrim>(
+        &mut self,
         inputs: &mut Inputs<F>,
         outputs: &mut Outputs<F>,
-        voice: &Voice<T>,
-    ) where
-        T: Renderable,
+        voice_data: &VoiceData
+    )
     {
         // for every output
         for output in outputs.into_iter() {
@@ -109,7 +111,7 @@ impl Renderable for Sound {
 
                 // Set our output buffer
                 *sample = *sample
-                    + ((r * AMPLIFY_MULTIPLIER) * (voice.note_data.velocity as f32 / 127f32)).as_();
+                    + ((r * AMPLIFY_MULTIPLIER) * (voice_data.note_data.velocity as f32 / 127f32)).as_();
             }
         }
     }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -93,7 +93,7 @@ where
     pub fn sample_rate(mut self, sample_rate: f64) -> Self {
         self.sample_rate = sample_rate;
         for voice in &self.voices {
-            voice.sample_rate.set(sample_rate);
+            voice.voice_data.sample_rate.set(sample_rate);
         }
         self
     }
@@ -184,12 +184,12 @@ where
         let mut i: usize = 0;
 
         for voice in &mut self.voices {
-            if voice.state == VoiceState::Off {
+            if voice.voice_data.state == VoiceState::Off {
                 // Success.  Push our data to the vector containing "on" voices
                 self.voices_used.push((note_data.note, i));
                 // set our note data
-                voice.note_data = note_data;
-                voice.state = VoiceState::On;
+                voice.voice_data.note_data = note_data;
+                voice.voice_data.state = VoiceState::On;
                 // exit early
                 break;
             }
@@ -210,7 +210,7 @@ where
         for &(note, voice_index) in &self.voices_used {
             if note == note_data.note {
                 // Also assign the value `note_data`
-                self.voices[voice_index].note_data = note_data;
+                self.voices[voice_index].voice_data.note_data = note_data;
                 remove_from_voices_used = true;
                 break;
             }


### PR DESCRIPTION
The `render_next()` method from the `Renderable` trait now has an `&mut self` parameter. This allows the implementation of `Renderable` to have some state. 
With Rust's borrowing system, the `render_next()` method can no longer get the full `Voice`, so I split off a `VoiceData` struct from the `Voice` struct and the `render_next()` method now gets only an `&VoiceData` parameter. I also had to change the `VoiceBuilder`. This allowed me to use the `Default` trait on some more places.