### PR TITLE
Make sure that automatically generated doc includes jack-backend.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 rust:
   - nightly
 after_success: |
-    cargo rustdoc \
+    cargo rustdoc --features jack-backend \
     && echo '<meta http-equiv=refresh content=0;url=rsynth/index.html>' > target/doc/index.html && \
     sudo pip install ghp-import && \
     ghp-import -n target/doc && \


### PR DESCRIPTION
I noticed that the documentation that is automatically generated in the CI pipeline does not include documentation about the Jack backend. This PR should fix that. 