### PR TITLE
Specify that docs.rs must document all features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ jack = "0.6.0"
 syllogism = "0.1"       # See also under dependencies.
 syllogism-macro = "0.1" # See also under dependencies.
 
-
+[package.metadata.docs.rs]
+all-features = true
 
 [[example]]
 name = "vst_synth"


### PR DESCRIPTION
Ensure that when publishing a new version, the documentation on [docs.rs](https://docs.rs/about) will include the documentation about features that are only enabled with cargo features (such as the different backends). 