### PR TITLE
Ensure that other crates can also define event types and voice identifiers

### DIFF
--- a/examples/test_synth.rs
+++ b/examples/test_synth.rs
@@ -10,6 +10,7 @@ use rsynth::utilities::polyphony::{
     EventDispatcher, RawMidiEventToneIdentifierDispatchClassifier, ToneIdentifier, Voice,
 };
 use rsynth::{AudioRendererMeta, CommonAudioPortMeta, CommonPluginMeta, ContextualAudioRenderer};
+use std::default::Default;
 
 use rsynth::event::raw_midi_event_event_types::*;
 
@@ -117,7 +118,7 @@ impl NoisePlayer {
         }
         Self {
             voices: voices,
-            dispatcher: SimpleEventDispatcher::new(RawMidiEventToneIdentifierDispatchClassifier),
+            dispatcher: SimpleEventDispatcher::default(),
         }
     }
 }

--- a/examples/test_synth.rs
+++ b/examples/test_synth.rs
@@ -6,8 +6,8 @@ use num_traits::Float;
 use rand::{thread_rng, Rng};
 use rsynth::event::{ContextualEventHandler, EventHandler, RawMidiEvent, SysExEvent, Timed};
 use rsynth::utilities::polyphony::{
-    voice_stealer::{SimpleVoiceState, SimpleVoiceStealer},
-    ToneIdentifier, Voice, VoiceStealer,
+    simple_event_dispatching::{SimpleEventDispatcher, SimpleVoiceState},
+    EventDispatcher, RawMidiEventToneIdentifierDispatchClassifier, ToneIdentifier, Voice,
 };
 use rsynth::{AudioRendererMeta, CommonAudioPortMeta, CommonPluginMeta, ContextualAudioRenderer};
 
@@ -106,7 +106,7 @@ impl EventHandler<Timed<RawMidiEvent>> for Noise {
 
 pub struct NoisePlayer {
     voices: Vec<Noise>,
-    dispatcher: SimpleVoiceStealer<ToneIdentifier>,
+    dispatcher: SimpleEventDispatcher<RawMidiEventToneIdentifierDispatchClassifier, Noise>,
 }
 
 impl NoisePlayer {
@@ -117,7 +117,7 @@ impl NoisePlayer {
         }
         Self {
             voices: voices,
-            dispatcher: SimpleVoiceStealer::new(),
+            dispatcher: SimpleEventDispatcher::new(RawMidiEventToneIdentifierDispatchClassifier),
         }
     }
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,5 +1,7 @@
 //! This module defines the `EventHandler` trait and some event types: `RawMidiEvent`,
 //! `SysExEvent`, ...
+use std::convert::{AsMut, AsRef};
+
 pub mod event_queue;
 
 /// The trait that plugins should implement in order to handle the given type of events.
@@ -95,3 +97,15 @@ where
 }
 
 impl<E> Copy for Timed<E> where E: Copy {}
+
+impl<E> AsRef<E> for Timed<E> {
+    fn as_ref(&self) -> &E {
+        &self.event
+    }
+}
+
+impl<E> AsMut<E> for Timed<E> {
+    fn as_mut(&mut self) -> &mut E {
+        &mut self.event
+    }
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -49,6 +49,18 @@ impl RawMidiEvent {
     }
 }
 
+impl AsRef<Self> for RawMidiEvent {
+    fn as_ref(&self) -> &RawMidiEvent {
+        self
+    }
+}
+
+impl AsMut<Self> for RawMidiEvent {
+    fn as_mut(&mut self) -> &mut RawMidiEvent {
+        self
+    }
+}
+
 pub mod raw_midi_event_event_types {
     pub const RAW_MIDI_EVENT_EVENT_TYPE_MASK: u8 = 0xF0;
     pub const RAW_MIDI_EVENT_NOTE_OFF: u8 = 0x80;

--- a/src/utilities/polyphony.rs
+++ b/src/utilities/polyphony.rs
@@ -29,6 +29,7 @@ where
     fn classify(&self, event: &Event) -> EventDispatchClass<Self::VoiceIdentifier>;
 }
 
+#[derive(Default)]
 pub struct RawMidiEventToneIdentifierDispatchClassifier;
 
 impl<Event> EventDispatchClassifier<Event> for RawMidiEventToneIdentifierDispatchClassifier
@@ -176,6 +177,18 @@ pub mod simple_event_dispatching {
         pub fn new(classifier: Classifier) -> Self {
             Self {
                 classifier,
+                _voice_phantom: PhantomData,
+            }
+        }
+    }
+
+    impl<Classifier, V> Default for SimpleEventDispatcher<Classifier, V>
+    where
+        Classifier: Default,
+    {
+        fn default() -> Self {
+            Self {
+                classifier: Classifier::default(),
                 _voice_phantom: PhantomData,
             }
         }

--- a/tests/polyphony.rs
+++ b/tests/polyphony.rs
@@ -1,0 +1,4 @@
+extern crate rsynth;
+
+
+fn main() {}

--- a/tests/polyphony.rs
+++ b/tests/polyphony.rs
@@ -1,4 +1,3 @@
 extern crate rsynth;
 
-
 fn main() {}


### PR DESCRIPTION
The trait `EventDispatchClassifier` is added so that other crates can work with custom events (midi event, ...) and with custom "Identifiers" (e.g. "ToneIdentifier" when different voices handle different tones).