### PR TITLE
Audio buffer

### DIFF
--- a/design.md
+++ b/design.md
@@ -118,6 +118,9 @@ So either this invariant needs to be given up, or `OutputChunk` needs to encapsu
 but this does not give such a straightforward and easy to use API.
 For this reason, I didn't keep the `OutputChunk` and continued to use the slices.
 
+Let on, I decided to use something like the `OutputChunk` struct anyway. I think the API is rather
+straightforward to use, but may need some small improvements here and there.
+
 Events
 ------
 Currently, backends that support one MIDI-port use the `Timed<RawMidiEvent>` type

--- a/examples/test_synth.rs
+++ b/examples/test_synth.rs
@@ -72,11 +72,8 @@ impl Noise {
         }
         let outputs = buffer.outputs();
         assert_eq!(2, outputs.number_of_channels());
-        // for every output
-        for channel_index in 0..2 {
-            let output = outputs.index_channel(channel_index);
-            // for each value in the buffer
-            for sample in output.iter_mut() {
+        for output_channel in outputs.channel_iter_mut() {
+            for sample in output_channel.iter_mut() {
                 // We "add" to the output.
                 // In this way, various noises can be heard together.
                 *sample =

--- a/src/backend/combined/dummy.rs
+++ b/src/backend/combined/dummy.rs
@@ -1,4 +1,5 @@
 use super::{AudioReader, AudioWriter, MidiWriter};
+use crate::buffer::AudioBufferOut;
 use crate::event::{DeltaEvent, RawMidiEvent};
 use std::marker::PhantomData;
 
@@ -14,7 +15,10 @@ impl<S> AudioDummy<S> {
     }
 }
 
-impl<S> AudioReader<S> for AudioDummy<S> {
+impl<S> AudioReader<S> for AudioDummy<S>
+where
+    S: Copy,
+{
     type Err = std::convert::Infallible;
     fn number_of_channels(&self) -> usize {
         0
@@ -24,7 +28,7 @@ impl<S> AudioReader<S> for AudioDummy<S> {
         44100
     }
 
-    fn fill_buffer(&mut self, _output: &mut [&mut [S]]) -> Result<usize, Self::Err> {
+    fn fill_buffer(&mut self, _output: &mut AudioBufferOut<S>) -> Result<usize, Self::Err> {
         Ok(0) // TODO: Have a look at this implementation again: is this logical?
     }
 }

--- a/src/backend/combined/dummy.rs
+++ b/src/backend/combined/dummy.rs
@@ -1,5 +1,5 @@
 use super::{AudioReader, AudioWriter, MidiWriter};
-use crate::buffer::AudioBufferOut;
+use crate::buffer::{AudioBufferIn, AudioBufferOut};
 use crate::event::{DeltaEvent, RawMidiEvent};
 use std::marker::PhantomData;
 
@@ -33,9 +33,12 @@ where
     }
 }
 
-impl<S> AudioWriter<S> for AudioDummy<S> {
+impl<S> AudioWriter<S> for AudioDummy<S>
+where
+    S: Copy,
+{
     type Err = std::convert::Infallible;
-    fn write_buffer(&mut self, _buffer: &[&[S]]) -> Result<(), Self::Err> {
+    fn write_buffer(&mut self, _buffer: &AudioBufferIn<S>) -> Result<(), Self::Err> {
         Ok(())
     }
 }

--- a/src/backend/combined/hound.rs
+++ b/src/backend/combined/hound.rs
@@ -83,7 +83,7 @@ where
         let length = outputs.number_of_frames();
         let mut frame_index = 0;
         while frame_index < length {
-            for output in outputs.iter_channel_mut() {
+            for output in outputs.channel_iter_mut() {
                 if let Some(sample) = self.hound_sample_reader.read_sample()? {
                     output[frame_index] = sample;
                 } else {

--- a/src/backend/combined/hound.rs
+++ b/src/backend/combined/hound.rs
@@ -1,4 +1,5 @@
 use super::{AudioReader, AudioWriter};
+use crate::buffer::AudioBufferOut;
 use hound::{WavReader, WavSamples, WavWriter};
 use sample::conv::{FromSample, ToSample};
 use std::io::{Read, Seek, Write};
@@ -65,7 +66,7 @@ where
 
 impl<'wr, S> AudioReader<S> for HoundAudioReader<'wr, S>
 where
-    S: FromSample<f32> + FromSample<i32> + FromSample<i16>,
+    S: Copy + FromSample<f32> + FromSample<i32> + FromSample<i16>,
 {
     type Err = hound::Error;
 
@@ -77,16 +78,12 @@ where
         self.frames_per_second
     }
 
-    fn fill_buffer(&mut self, outputs: &mut [&mut [S]]) -> Result<usize, Self::Err> {
-        assert_eq!(outputs.len(), self.number_of_channels());
-        assert!(self.number_of_channels() > 0);
-        let length = outputs[0].len();
-        for output in outputs.iter() {
-            assert_eq!(output.len(), length);
-        }
+    fn fill_buffer(&mut self, outputs: &mut AudioBufferOut<S>) -> Result<usize, Self::Err> {
+        assert_eq!(outputs.number_of_channels(), self.number_of_channels());
+        let length = outputs.number_of_frames();
         let mut frame_index = 0;
         while frame_index < length {
-            for output in outputs.iter_mut() {
+            for output in outputs.iter_channel_mut() {
                 if let Some(sample) = self.hound_sample_reader.read_sample()? {
                     output[frame_index] = sample;
                 } else {

--- a/src/backend/combined/memory.rs
+++ b/src/backend/combined/memory.rs
@@ -52,7 +52,7 @@ where
         let frames_to_copy = std::cmp::min(buffer_size, remainder);
 
         for (output_channel, input_channel) in
-            output.iter_channel_mut().zip(self.buffer.channels().iter())
+            output.channel_iter_mut().zip(self.buffer.channels().iter())
         {
             assert_eq!(buffer_size, output_channel.len());
             output_channel[0..frames_to_copy]

--- a/src/backend/combined/memory.rs
+++ b/src/backend/combined/memory.rs
@@ -1,5 +1,5 @@
 use super::{AudioReader, AudioWriter};
-use crate::buffer::{AudioBufferOut, AudioChunk};
+use crate::buffer::{AudioBufferIn, AudioBufferOut, AudioChunk};
 
 /// An [`AudioReader`] that reads from a given [`AudioChunk`].
 /// The generic parameter type `S` represents the sample type.
@@ -78,21 +78,21 @@ mod AudioBufferReaderTests {
             let mut output_buffer = AudioChunk::zero(3, 2);
             let mut slices = output_buffer.as_mut_slices();
             {
-                let mut buffers = AudioBufferOut::new(&mut slices, 4);
+                let mut buffers = AudioBufferOut::new(&mut slices, 2);
                 assert_eq!(Ok(2), reader.fill_buffer(&mut buffers));
             }
             assert_eq!(slices[0], vec![1, 2].as_slice());
             assert_eq!(slices[1], vec![6, 7].as_slice());
             assert_eq!(slices[2], vec![11, 12].as_slice());
             {
-                let mut buffers = AudioBufferOut::new(&mut slices, 4);
+                let mut buffers = AudioBufferOut::new(&mut slices, 2);
                 assert_eq!(Ok(2), reader.fill_buffer(&mut buffers));
             }
             assert_eq!(slices[0], vec![3, 4].as_slice());
             assert_eq!(slices[1], vec![8, 9].as_slice());
             assert_eq!(slices[2], vec![13, 14].as_slice());
             {
-                let mut buffers = AudioBufferOut::new(&mut slices, 4);
+                let mut buffers = AudioBufferOut::new(&mut slices, 2);
                 assert_eq!(Ok(1), reader.fill_buffer(&mut buffers));
             }
             assert_eq!(slices[0], vec![5, 4].as_slice());
@@ -127,8 +127,8 @@ where
     S: Copy,
 {
     type Err = std::convert::Infallible;
-    fn write_buffer(&mut self, buffer: &[&[S]]) -> Result<(), Self::Err> {
-        self.buffer.append_sliced_chunk(buffer);
+    fn write_buffer(&mut self, buffer: &AudioBufferIn<S>) -> Result<(), Self::Err> {
+        self.buffer.append_sliced_chunk(buffer.channels());
         Ok(())
     }
 }

--- a/src/backend/combined/mod.rs
+++ b/src/backend/combined/mod.rs
@@ -229,7 +229,7 @@ where
 
         let inputs = buffers_as_slice(&input_buffers, frames_read);
         let mut outputs = buffers_as_mut_slice(&mut output_buffers, frames_read);
-        let mut buffer = AudioBufferInOut::new(&inputs, &mut outputs, buffer_size_in_frames);
+        let mut buffer = AudioBufferInOut::new(&inputs, &mut outputs, frames_read);
         plugin.render_buffer(&mut buffer, &mut writer);
 
         if let Err(e) = audio_out.write_buffer(&buffers_as_slice(&output_buffers, frames_read)) {

--- a/src/backend/jack_backend.rs
+++ b/src/backend/jack_backend.rs
@@ -8,6 +8,7 @@
 //!
 //! [JACK]: http://www.jackaudio.org/
 //! [the cargo reference]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
+use crate::buffer::AudioBufferInOut;
 use crate::event::{EventHandler, Indexed};
 use crate::{
     backend::HostInterface,
@@ -295,8 +296,12 @@ where
             outputs.push(buffer);
         }
 
-        self.plugin
-            .render_buffer(inputs.as_slice(), outputs.as_mut_slice(), &mut jack_host);
+        let mut buffer = AudioBufferInOut::new(
+            inputs.as_slice(),
+            outputs.as_mut_slice(),
+            client.buffer_size() as usize,
+        );
+        self.plugin.render_buffer(&mut buffer, &mut jack_host);
         Control::Continue
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -42,36 +42,26 @@ pub trait HostInterface {
     /// # Example
     ///
     /// The following example illustrates how `output_initialized()` can be used in
-    /// combination with [`rsynth::utilities::zero_init`] to initialize the output
+    /// combination with the `set` method on `AudioBufferOut` to initialize the output
     /// buffers to zero in an implementation of the [`ContextualAudioRenderer`] trait.
     ///
     /// ```
     /// use rsynth::ContextualAudioRenderer;
-    /// # use rsynth::{AudioHandlerMeta, AudioHandler};
     /// use rsynth::backend::HostInterface;
-    /// use rsynth::buffer::initialize_to_zero;
-    /// # struct MyPlugin {}
-    /// # impl AudioHandlerMeta for MyPlugin {
-    /// #    fn max_number_of_audio_inputs(&self) -> usize { 0 }
-    /// #    fn max_number_of_audio_outputs(&self) -> usize { 2 }
-    /// # }
-    /// # impl AudioHandler for MyPlugin {
-    /// #    fn set_sample_rate(&mut self,sample_rate: f64) {
-    /// #    }
-    /// # }
+    /// use rsynth::buffer::{AudioBufferInOut};
+    /// struct MyPlugin { /* ... */ }
     /// impl<H> ContextualAudioRenderer<f32, H> for MyPlugin
     /// where H: HostInterface
     /// {
     ///     fn render_buffer(
     ///         &mut self,
-    ///         inputs: &[&[f32]],
-    ///         outputs: &mut [&mut [f32]],
+    ///         buffer: &mut AudioBufferInOut<f32>,
     ///         context: &mut H)
     ///     {
     ///         if ! context.output_initialized() {
-    ///             initialize_to_zero(outputs);
-    ///             // The rest of the audio rendering.
+    ///             buffer.outputs().set(0.0);
     ///         }
+    ///         // The rest of the audio rendering.
     ///     }
     /// }
     /// ```

--- a/src/backend/vst_backend.rs
+++ b/src/backend/vst_backend.rs
@@ -234,6 +234,7 @@ impl HostInterface for HostCallback {
 ///
 /// use asprim::AsPrim;
 /// use num_traits::Float;
+/// # use rsynth::buffer::AudioBufferInOut;
 ///
 /// impl AudioHandler for MyPlugin {
 ///     // Implementation omitted for brevity.
@@ -247,7 +248,7 @@ impl HostInterface for HostCallback {
 ///     H: HostInterface,
 /// {
 ///     // Implementation omitted for brevity.
-/// #    fn render_buffer(&mut self, inputs: &[&[S]], outputs: &mut[&mut[S]], context: &mut H)
+/// #    fn render_buffer(&mut self, buffer: &mut AudioBufferInOut<S>, context: &mut H)
 /// #    {
 /// #        unimplemented!()
 /// #    }

--- a/src/backend/vst_backend.rs
+++ b/src/backend/vst_backend.rs
@@ -13,6 +13,7 @@
 //! [`vst_init`]: ../../macro.vst_init.html
 //! [the cargo reference]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 use crate::backend::HostInterface;
+use crate::buffer::AudioBufferInOut;
 use crate::event::{ContextualEventHandler, RawMidiEvent, SysExEvent, Timed};
 use crate::{
     AudioHandler, AudioHandlerMeta, CommonAudioPortMeta, CommonPluginMeta, ContextualAudioRenderer,
@@ -82,6 +83,7 @@ where
     }
 
     pub fn process<'b>(&mut self, buffer: &mut AudioBuffer<'b, f32>) {
+        let number_of_frames = buffer.samples();
         let (input_buffers, mut output_buffers) = buffer.split();
 
         let mut inputs = self.inputs_f32.vec_guard();
@@ -96,11 +98,13 @@ where
             outputs.push(output_buffers.get_mut(i));
         }
 
-        self.plugin
-            .render_buffer(inputs.as_slice(), outputs.as_mut_slice(), &mut self.host);
+        let mut audio_buffer =
+            AudioBufferInOut::new(inputs.as_slice(), outputs.as_mut_slice(), number_of_frames);
+        self.plugin.render_buffer(&mut audio_buffer, &mut self.host);
     }
 
     pub fn process_f64<'b>(&mut self, buffer: &mut AudioBuffer<'b, f64>) {
+        let number_of_frames = buffer.samples();
         let (input_buffers, mut output_buffers) = buffer.split();
 
         let mut inputs = self.inputs_f64.vec_guard();
@@ -115,8 +119,9 @@ where
             outputs.push(output_buffers.get_mut(i));
         }
 
-        self.plugin
-            .render_buffer(inputs.as_slice(), outputs.as_mut_slice(), &mut self.host);
+        let mut audio_buffer =
+            AudioBufferInOut::new(inputs.as_slice(), outputs.as_mut_slice(), number_of_frames);
+        self.plugin.render_buffer(&mut audio_buffer, &mut self.host);
     }
 
     pub fn get_input_info(&self, input_index: i32) -> ChannelInfo {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -459,14 +459,22 @@ impl<'in_channels, 'in_samples, 'out_channels, 'out_samples, S>
 where
     S: 'static + Copy,
 {
+    /// # Panics
+    /// Panics if one of the following happens:
+    /// * not all elements of `inputs` have the same length,
+    /// * not all elements of `outputs` have the same length,
+    /// * not all elements of `inputs` have the same length as all the elements of `outputs`
     pub fn new(
         inputs: &'in_channels [&'in_samples [S]],
         outputs: &'out_channels mut [&'out_samples mut [S]],
         length: usize,
     ) -> Self {
+        let inputs = AudioBufferIn::new(inputs, length);
+        let outputs = AudioBufferOut::new(outputs, length);
+        assert_eq!(inputs.number_of_frames(), outputs.number_of_frames());
         AudioBufferInOut {
-            inputs: AudioBufferIn::new(inputs, length),
-            outputs: AudioBufferOut::new(outputs, length),
+            inputs,
+            outputs,
             length,
         }
     }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -419,6 +419,20 @@ where
             inner: self.outputs.iter_mut(),
         }
     }
+
+    pub fn as_audio_buffer_in<'s, 'vec>(
+        &'s self,
+        vec: &'vec mut Vec<&'s [S]>,
+    ) -> AudioBufferIn<'vec, 's, S> {
+        vec.clear();
+        for channel in self.outputs.iter() {
+            vec.push(&**channel);
+        }
+        AudioBufferIn {
+            inputs: vec,
+            length: self.length,
+        }
+    }
 }
 
 pub struct AudioBufferOutChannelIteratorMut<'channels, 'samples, S> {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -403,6 +403,15 @@ where
     pub fn index_channel(&mut self, index: usize) -> &mut [S] {
         self.outputs[index]
     }
+
+    /// Set all samples to the given value.
+    pub fn set(&mut self, value: S) {
+        for channel in self.outputs.iter_mut() {
+            for sample in channel.iter_mut() {
+                *sample = value;
+            }
+        }
+    }
 }
 
 #[test]
@@ -898,14 +907,4 @@ pub fn buffers_as_mut_slice<'a, S>(
     slice_len: usize,
 ) -> Vec<&'a mut [S]> {
     buffers.iter_mut().map(|b| &mut b[0..slice_len]).collect()
-}
-
-/// Initialize a slice of buffers to zero.
-// TODO: what we really want is silence (equilibrium).
-pub fn initialize_to_zero<S: num_traits::Zero>(buffers: &mut [&mut [S]]) {
-    for buffer in buffers.iter_mut() {
-        for sample in buffer.iter_mut() {
-            *sample = S::zero();
-        }
-    }
 }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -412,6 +412,25 @@ where
             }
         }
     }
+
+    /// Get an iterator over the channels
+    pub fn iter_channel_mut<'a>(&'a mut self) -> AudioBufferOutChannelIteratorMut<'a, 'samples, S> {
+        AudioBufferOutChannelIteratorMut {
+            inner: self.outputs.iter_mut(),
+        }
+    }
+}
+
+pub struct AudioBufferOutChannelIteratorMut<'channels, 'samples, S> {
+    inner: std::slice::IterMut<'channels, &'samples mut [S]>,
+}
+
+impl<'channels, 'samples, S> Iterator for AudioBufferOutChannelIteratorMut<'channels, 'samples, S> {
+    type Item = &'channels mut [S];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|x| &mut **x)
+    }
 }
 
 #[test]

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -635,6 +635,14 @@ where
             },
         )
     }
+
+    pub fn inputs(&self) -> &AudioBufferIn<'in_channels, 'in_samples, S> {
+        &self.inputs
+    }
+
+    pub fn outputs(&mut self) -> &mut AudioBufferOut<'out_channels, 'out_samples, S> {
+        &mut self.outputs
+    }
 }
 
 // Alternative name: "packet"?

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -414,7 +414,7 @@ where
     }
 
     /// Get an iterator over the channels
-    pub fn iter_channel_mut<'a>(&'a mut self) -> AudioBufferOutChannelIteratorMut<'a, 'samples, S> {
+    pub fn channel_iter_mut<'a>(&'a mut self) -> AudioBufferOutChannelIteratorMut<'a, 'samples, S> {
         AudioBufferOutChannelIteratorMut {
             inner: self.outputs.iter_mut(),
         }

--- a/src/event/event_queue.rs
+++ b/src/event/event_queue.rs
@@ -196,22 +196,6 @@ impl<T> EventQueue<T> {
         self.queue.get(0)
     }
 
-    fn render<'storage, 's, 'chunk, S, R, C>(
-        start: usize,
-        stop: usize,
-        input_storage: &'storage mut VecStorage<&'static [S]>,
-        output_storage: &'storage mut VecStorage<&'static mut [S]>,
-        inputs: &[&[S]],
-        outputs: &mut [&mut [S]],
-        renderer: &mut R,
-        context: &mut C,
-    ) where
-        S: Copy + 'static,
-        R: ContextualAudioRenderer<S, C>,
-    {
-        unimplemented!();
-    }
-
     pub fn split<'in_storage, 'out_storage, 'in_channels, 's, 'chunk, S, R, C>(
         &mut self,
         input_storage: &'in_storage mut VecStorage<&'static [S]>,
@@ -223,7 +207,6 @@ impl<T> EventQueue<T> {
         S: Copy + 'static,
         R: ContextualAudioRenderer<S, C> + EventHandler<T>,
         T: std::fmt::Debug,
-        // 'in_storage: 'in_channels,
     {
         let buffer_length = buffer.number_of_frames();
         let mut last_event_time = 0;
@@ -356,117 +339,6 @@ impl<T> Deref for EventQueue<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.queue
-    }
-}
-
-// TODO: Move to a better place in the module hierarchy.
-pub fn mid<'storage, 'chunk, 's, S>(
-    storage: &'storage mut VecStorage<&'static [S]>,
-    chunk: &'chunk [&'s [S]],
-    start: usize,
-    end: usize,
-) -> VecGuard<'storage, &'static [S], &'chunk [S]> {
-    let mut remaining_chunk = chunk;
-    let mut guard = storage.vec_guard();
-    let mut len = remaining_chunk.len();
-    while len > 0 {
-        let (first_channel, other_channels) = remaining_chunk.split_at(1);
-        let channel = &(first_channel[0]);
-        let (first, _) = channel.split_at(end);
-        let (_, middle) = first.split_at(start);
-        guard.push(middle);
-        remaining_chunk = other_channels;
-        len = remaining_chunk.len();
-    }
-    guard
-}
-
-// TODO: Move to a better place in the module hierarchy.
-///
-/// ## Panics
-/// Panics if `start` > `end` or if `end` > the length of any item in `chunk`.
-pub fn mid_mut<'storage, 'chunk, 's, S>(
-    storage: &'storage mut VecStorage<&'static mut [S]>,
-    chunk: &'chunk mut [&'s mut [S]],
-    start: usize,
-    end: usize,
-) -> VecGuard<'storage, &'static mut [S], &'chunk mut [S]> {
-    let mut remaining_chunk = chunk;
-    let mut guard = storage.vec_guard();
-    let mut len = remaining_chunk.len();
-    while len > 0 {
-        let (first_channel, other_channels) = remaining_chunk.split_at_mut(1);
-        let channel = &mut (first_channel[0]);
-        let (first, _) = channel.split_at_mut(end);
-        let (_, middle) = first.split_at_mut(start);
-        guard.push(middle);
-        remaining_chunk = other_channels;
-        len = remaining_chunk.len();
-    }
-    guard
-}
-
-#[test]
-fn mid_mut_works() {
-    let mut storage = VecStorage::with_capacity(2);
-    let mut channel1 = [11, 12, 13, 14];
-    let mut channel2 = [21, 22, 23, 24];
-    let chunk: &mut [&mut [_]] = &mut [&mut channel1, &mut channel2];
-    {
-        let guard = mid_mut(&mut storage, chunk, 0, 0);
-        assert_eq!(guard.len(), 2);
-        assert!(guard[0].is_empty());
-        assert!(guard[1].is_empty());
-    }
-    {
-        let guard = mid_mut(&mut storage, chunk, 0, 1);
-        assert_eq!(guard.len(), 2);
-        assert_eq!(guard[0], &mut [11]);
-        assert_eq!(guard[1], &mut [21]);
-    }
-    {
-        let guard = mid_mut(&mut storage, chunk, 0, 2);
-        assert_eq!(guard.len(), 2);
-        assert_eq!(guard[0], &mut [11, 12]);
-        assert_eq!(guard[1], &mut [21, 22]);
-    }
-    {
-        let guard = mid_mut(&mut storage, chunk, 1, 2);
-        assert_eq!(guard.len(), 2);
-        assert_eq!(guard[0], &mut [12]);
-        assert_eq!(guard[1], &mut [22]);
-    }
-}
-
-#[test]
-fn mid_works() {
-    let mut storage = VecStorage::with_capacity(2);
-    let channel1 = [11, 12, 13, 14];
-    let channel2 = [21, 22, 23, 24];
-    let chunk: &[&[_]] = &[&channel1, &channel2];
-    {
-        let guard = mid(&mut storage, chunk, 0, 0);
-        assert_eq!(guard.len(), 2);
-        assert!(guard[0].is_empty());
-        assert!(guard[1].is_empty());
-    }
-    {
-        let guard = mid(&mut storage, chunk, 0, 1);
-        assert_eq!(guard.len(), 2);
-        assert_eq!(guard[0], &[11]);
-        assert_eq!(guard[1], &[21]);
-    }
-    {
-        let guard = mid(&mut storage, chunk, 0, 2);
-        assert_eq!(guard.len(), 2);
-        assert_eq!(guard[0], &[11, 12]);
-        assert_eq!(guard[1], &[21, 22]);
-    }
-    {
-        let guard = mid(&mut storage, chunk, 1, 2);
-        assert_eq!(guard.len(), 2);
-        assert_eq!(guard[0], &[12]);
-        assert_eq!(guard[1], &[22]);
     }
 }
 

--- a/src/event/event_queue.rs
+++ b/src/event/event_queue.rs
@@ -311,7 +311,9 @@ fn split_works() {
     let mut input_storage = VecStorage::with_capacity(2);
     let mut output_storage = VecStorage::with_capacity(2);
     let mut result_event_handler = DummyEventHandler;
-    let mut buffer = AudioBufferInOut::new(&input.channels(), &mut output, 4);
+    let input = input.as_slices();
+    let mut output = output.as_mut_slices();
+    let mut buffer = AudioBufferInOut::new(&input, &mut output, 4);
     queue.split(
         &mut input_storage,
         &mut output_storage,
@@ -337,6 +339,8 @@ fn split_works_with_empty_event_queue() {
     let mut input_storage = VecStorage::with_capacity(2);
     let mut output_storage = VecStorage::with_capacity(2);
     let mut result_event_handler = DummyEventHandler;
+    let input = input.as_slices();
+    let mut output = output.as_mut_slices();
     let mut buffer = AudioBufferInOut::new(&input, &mut output, 4);
     queue.split(
         &mut input_storage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,9 +127,9 @@ doctest!("../README.md");
 ///
 /// Backends that require the plugin to implement this trait ensure that when calling the
 /// [`render_buffer`] method of the [`AudioRenderer`] trait
-/// *  the number of inputs (`inputs.len()`) is smaller than or equal to
+/// *  the number of inputs channels (`buffer.number_of_input_channels()`) is smaller than or equal to
 ///    `Self::max_number_of_audio_inputs()` and
-/// * the number of outputs (`outputs.len()`) is smaller than or equal to
+/// * the number of outputs (`buffer.number_of_output_channels()`) is smaller than or equal to
 ///    `Self::max_number_of_audio_outputs()`.
 ///
 /// # Remark
@@ -192,9 +192,8 @@ where
 /// Defines how audio is rendered, similar to the [`AudioRenderer`] trait.
 /// The extra parameter `context` can be used by the backend to provide extra information.
 ///
-/// See the documentation of [`AudioRenderer`] for more information.
-///
-/// [`AudioRenderer`]: ./trait.AudioHandlerMeta.html
+/// The type parameter `S` refers to the data type of a sample.
+/// It is typically `f32` or `f64`.
 pub trait ContextualAudioRenderer<S, Context>
 where
     S: Copy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! * [`combined`] combine different back-ends for audio input, audio output, midi input and
 //!     midi output, mostly for offline rendering and testing (behind various features)
 //! * [`jack`] (behind the `backend-jack` feature)
-//! * [`vst`] (behind the backend-vst)
+//! * [`vst`] (behind the `backend-vst` feature)
 //!
 //! See the documentation of each back-end for more information.
 //!
@@ -19,10 +19,10 @@
 //! * the [`AudioRenderer`] trait
 //! * the [`ContextualAudioRenderer`] trait
 //!
-//! These traits are very similar, the [`ContextualAudioRenderer`] trait adds one extra parameter
-//! that defines a "context" that can be passed to the implementor of the trait, so that the
-//! implementor of the trait does not need to own all data that is needed for rendering the audio;
-//! it can also borrow some data with additional the `context` parameter.
+//! The difference between these traits is that the [`ContextualAudioRenderer`] trait adds one extra
+//! parameter that defines a "context" that can be passed to the implementor of the trait, so that
+//! the implementor of the trait does not need to own all data that is needed for rendering the
+//! audio; it can also borrow some data with additional the `context` parameter.
 //!
 //! Both traits are generic over the data type that represents the sample.
 //! For which specific data-type an application or plugin needs to implement the trait, depends on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@
 //!
 //! * polyphony: managing of different voices
 //!
-//! [`Plugin`]: ./trait.Plugin.html
 //! [`jack`]: ./backend/jack_backend/index.html
 //! [`vst`]: ./backend/vst_backend/index.html
 //! [`combined`]: ./backend/combined/index.html
@@ -110,6 +109,7 @@ extern crate vst;
 #[macro_use]
 extern crate doc_comment;
 
+use crate::buffer::AudioBufferInOut;
 use crate::meta::{AudioPort, General, Meta, MidiPort, Name, Port};
 
 #[macro_use]
@@ -176,17 +176,17 @@ pub trait MidiHandlerMeta {
     fn max_number_of_midi_outputs(&self) -> usize;
 }
 
+// TODO: Is this trait actually used?
 /// Defines how audio is rendered.
 ///
 /// The type parameter `S` refers to the data type of a sample.
 /// It is typically `f32` or `f64`.
-pub trait AudioRenderer<S> {
+pub trait AudioRenderer<S>
+where
+    S: Copy,
+{
     /// This method is called repeatedly for subsequent audio buffers.
-    ///
-    /// The lengths of all elements of `inputs` and the lengths of all elements of `outputs`
-    /// are all guaranteed to equal to each other.
-    /// This shared length can however be different for subsequent calls to `render_buffer`.
-    fn render_buffer(&mut self, inputs: &[&[S]], outputs: &mut [&mut [S]]);
+    fn render_buffer(&mut self, buffer: &mut AudioBufferInOut<S>);
 }
 
 /// Defines how audio is rendered, similar to the [`AudioRenderer`] trait.
@@ -195,7 +195,10 @@ pub trait AudioRenderer<S> {
 /// See the documentation of [`AudioRenderer`] for more information.
 ///
 /// [`AudioRenderer`]: ./trait.AudioHandlerMeta.html
-pub trait ContextualAudioRenderer<S, Context> {
+pub trait ContextualAudioRenderer<S, Context>
+where
+    S: Copy,
+{
     /// This method called repeatedly for subsequent buffers.
     ///
     /// It is similar to the [`render_buffer`] from the [`AudioRenderer`] trait,
@@ -203,7 +206,7 @@ pub trait ContextualAudioRenderer<S, Context> {
     ///
     /// [`AudioRenderer`]: ./trait.AudioHandlerMeta.html
     /// [`render_buffer`]: ./trait.AudioHandlerMeta.html#tymethod.render_buffer
-    fn render_buffer(&mut self, inputs: &[&[S]], outputs: &mut [&mut [S]], context: &mut Context);
+    fn render_buffer(&mut self, buffer: &mut AudioBufferInOut<S>, context: &mut Context);
 }
 
 /// Provides common meta-data of the plugin or application to the host.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! it can also borrow some data with additional the `context` parameter.
 //!
 //! Both traits are generic over the data type that represents the sample.
-//! For which precise data-type an application or plugin needs to implement the trait, depends on
+//! For which specific data-type an application or plugin needs to implement the trait, depends on
 //! the back-end. Because the trait is generic, the application or plugin can have a generic implementation
 //! as well that can be used by different back-ends.
 //!
@@ -46,7 +46,7 @@
 //! * [`CommonPluginMeta`]
 //!     * Name of the plugin or application
 //!
-//! Additionally, back-ends can require extra trait bounds related to meta-data.
+//! Additionally, back-ends can require extra trait related to meta-data.
 //!
 //! ## Handling events
 //! Plugins or application can handle events by implementing a number of traits:
@@ -60,13 +60,13 @@
 //! implementor of the trait does not need to own all data that is needed for handling the event;
 //! it can also borrow some data with additional the `context` parameter.
 //!
-//! ## Events
+//! ### Events
 //! `rsynth` defines a number of event types:
 //!
 //! * [`RawMidiEvent`]: a raw MIDI event
 //! * [`SysExEvent`]: a system exclusive event
-//! * [`Timed<T>`]: a timed event
-//! * [`Indexed<T>`]:
+//! * [`Timed<T>`]: a generic timed event
+//! * [`Indexed<T>`]: a generic event that associates a timestamp with the event
 //!
 //! ## Utilities
 //! Utilities are are types that you can include to perform several common tasks for the

--- a/src/test_utilities/mod.rs
+++ b/src/test_utilities/mod.rs
@@ -156,23 +156,6 @@ where
                 .copy_from_slice(expected_output_channel);
         }
 
-        todo!();
-        /*
-        for (output_channel_index, output_channel) in outputs.iter_mut().enumerate() {
-            let expected_output_channel = &expected_output_channels[output_channel_index];
-            assert_eq!(
-                output_channel.len(),
-                expected_output_channel.len(),
-                "mismatch in output channel #{} in buffer #{}: \
-                 expected one with length {}, but got one with length {}",
-                output_channel_index,
-                self.buffer_index,
-                expected_output_channel.len(),
-                output_channel.len()
-            );
-            output_channel.copy_from_slice(expected_output_channel);
-        }
-        */
         let events = self.provided_events.drain(..1).next().unwrap();
         for event in events {
             context.handle_event(event);

--- a/src/test_utilities/mod.rs
+++ b/src/test_utilities/mod.rs
@@ -1,6 +1,6 @@
 //! Utilities for testing.
 
-use crate::buffer::AudioChunk;
+use crate::buffer::{AudioBufferInOut, AudioChunk};
 use crate::event::{ContextualEventHandler, EventHandler};
 use crate::{AudioHandler, AudioHandlerMeta, ContextualAudioRenderer};
 use std::fmt::Debug;
@@ -80,7 +80,7 @@ where
     S: PartialEq + Debug + Copy,
     C: EventHandler<E>,
 {
-    fn render_buffer(&mut self, inputs: &[&[S]], outputs: &mut [&mut [S]], context: &mut C) {
+    fn render_buffer(&mut self, buffer: &mut AudioBufferInOut<S>, context: &mut C) {
         assert!(
             self.buffer_index < self.expected_inputs.len(),
             "`render_buffer` called more often than expected: expected only {} times",
@@ -99,13 +99,13 @@ where
 
         let expected_input_channels = &self.expected_inputs[self.buffer_index].channels();
         assert_eq!(
-            inputs.len(),
+            buffer.number_of_input_channels(),
             expected_input_channels.len(),
             "`render_buffer` called with {} input channels, but {} were expected",
-            inputs.len(),
+            buffer.number_of_input_channels(),
             expected_input_channels.len()
         );
-        for (input_channel_index, input_channel) in inputs.iter().enumerate() {
+        for (input_channel_index, input_channel) in buffer.inputs().channels().iter().enumerate() {
             let expected_input_channel = &expected_input_channels[input_channel_index];
             assert_eq!(
                 input_channel.len(),
@@ -132,8 +132,32 @@ where
             }
         }
 
-        let expected_output_channels = &self.provided_outputs[self.buffer_index].channels();
-        assert_eq!(outputs.len(), expected_output_channels.len());
+        let expected_output_channels = self.provided_outputs[self.buffer_index].channels();
+        assert_eq!(
+            buffer.number_of_output_channels(),
+            expected_output_channels.len()
+        );
+        // TODO: Use an iterator here.
+        for output_channel_index in 0..expected_output_channels.len() {
+            let expected_output_channel = &expected_output_channels[output_channel_index];
+            assert_eq!(
+                buffer.number_of_frames(),
+                expected_output_channel.len(),
+                "mismatch in output channel #{} in buffer #{}: \
+                 expected one with length {}, but got one with length {}",
+                output_channel_index,
+                self.buffer_index,
+                expected_output_channel.len(),
+                buffer.number_of_frames()
+            );
+            buffer
+                .outputs()
+                .index_channel(output_channel_index)
+                .copy_from_slice(expected_output_channel);
+        }
+
+        todo!();
+        /*
         for (output_channel_index, output_channel) in outputs.iter_mut().enumerate() {
             let expected_output_channel = &expected_output_channels[output_channel_index];
             assert_eq!(
@@ -148,7 +172,7 @@ where
             );
             output_channel.copy_from_slice(expected_output_channel);
         }
-
+        */
         let events = self.provided_events.drain(..1).next().unwrap();
         for event in events {
             context.handle_event(event);


### PR DESCRIPTION
Instead of raw slices, use structs that represent the audio buffer. This has the advantage that there is more guarantee that all channels have the same length and it also has the advantage that we can know the channel length when there are 0 channels (may be needed for MIDI processing).